### PR TITLE
meta: disable depedency dashboard for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": ["config:base"],
+    "dependencyDashboard": false,
     "packageRules": [
       {
         "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## What

This PR disables the dependency dashboard for renovate bot.

## Why

As discussed with @ZanMarolt, we don't need this dashboard up and running. For now it creates more noise than what it helps resolve.

## How

By setting "dependencyDashboard" to `false` in the renovate config as per the [renovate docs on how to disable the dashboard](https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard).