### PR TITLE
fix tag creation branch filter

### DIFF
--- a/.github/workflows/createtag.yml
+++ b/.github/workflows/createtag.yml
@@ -1,7 +1,8 @@
 name: Create tag on updated version
 on:
   push:
-    branch: "main"
+    branches:
+     - main
 
 jobs:
   create-tag:


### PR DESCRIPTION
## About the changes
After checking the ci logs, I noticed the tag creation action gets ran on any branch push 🤦 , not only on the main branch. After investigating I noticed there might be a problem with the branch filtering within the action itself.

## Discussion points
I did check the docs this time around, hopefully this fixes the bug. 🤞 
Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters

I would like to remove the tags created by the renovate pull request (`4.16.1`), if somebody with permissions can do so, so we can see if this works by rerunning the renovate PR. #29 
