### PR TITLE
Attempt to fix version push

### DIFF
--- a/.github/workflows/buildtags.yml
+++ b/.github/workflows/buildtags.yml
@@ -1,8 +1,9 @@
 name: Build and publish tag
 on:
-  push:
-    tags:
-      - '*'
+  workflow_run:
+    workflows: ["Create tag on updated version"]
+    types:
+      - completed
 
 jobs:
   build:


### PR DESCRIPTION
## About the changes
I have noticed that the tag versions aren't pushed to docker hub anymore. This seems that it is due to github action permission. Trying out if workflow can trigger another workflow by calling it directly instead of relying on a git tag pushed by another workflow, which does not seem to work.
