### PR TITLE
fix: google publishing

### DIFF
--- a/.github/workflows/buildtags.yml
+++ b/.github/workflows/buildtags.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - id: retrieve-version
+        name: Retrieve version
         run: |
           PACKAGE_VERSION=$(cat platforms/${{ matrix.folder }}/package.json \
           | grep unleash-server \
@@ -26,9 +27,11 @@ jobs:
           | sed 's/[", ]//g')
           MAJOR=$(echo $PACKAGE_VERSION | cut -d. -f1)
           MINOR=$(echo $PACKAGE_VERSION | cut -d. -f2)
+          set -x
           echo "::set-output name=version::${PACKAGE_VERSION}"
           echo "::set-output name=major::${MAJOR}"
           echo "::set-output name=minor::${MINOR}"
+          set +x
       - name: Setup QEmu so we can build multiplatform
         uses: docker/setup-qemu-action@v3
       - name: Login to docker hub

--- a/platforms/google/package.json
+++ b/platforms/google/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "@passport-next/passport": "^3.1.0",
     "passport-google-oidc": "^0.1.0",
-    "unleash-server": "^6.0.0"
+    "unleash-server": "6.0.6"
   }
 }

--- a/platforms/google/yarn.lock
+++ b/platforms/google/yarn.lock
@@ -3654,7 +3654,7 @@ unleash-client@5.5.3:
     murmurhash3js "^3.0.1"
     semver "^7.5.3"
 
-unleash-server@^6.0.0:
+unleash-server@6.0.6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/unleash-server/-/unleash-server-6.0.6.tgz#3bbfdc852016624c108ad19b65157e0ecd3a4732"
   integrity sha512-6dWKtX1soCGXYlBH0O2u4XqppHlTsC96oNxSmlbwq0ba2T5O5AkxeZbX+8ydoQSaY0lsJpwnkKcQOS/fk73S6w==


### PR DESCRIPTION
This issue seems to be related with the inclusion of a ^ in front of unleash-server version.

![image(2)](https://github.com/user-attachments/assets/ad516ad8-efed-415c-8ae2-12fff83cfb08)

This removes it and enables us to get more insights on the output of the step fetching the version.

Fixes: #157 